### PR TITLE
Initial build 1.3.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - sfe1ed40
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  # s390x missing cvxopt
+  skip: true  # [py<37 or s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # s390x missing cvxopt
-  skip: true  # [py<37 or s390x]
+  skip: true  # [py<37]
 
 requirements:
   build:
@@ -27,7 +27,7 @@ outputs:
   - name: cvxpy
     build:
       # scs missing on Windows
-      skip: true  # [win]
+      skip: true  # [win or s390x]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,8 @@ requirements:
 outputs:
   - name: cvxpy
     build:
-      # scs missing on Windows
-      skip: true  # [win or s390x]
+      # Windows missing scs
+      skip: true  # [win]
     requirements:
       host:
         - python
@@ -41,7 +41,8 @@ outputs:
       requires:
         - pip
         - pytest
-        - cvxopt
+        # cvxopt required for tests, missing on s390x
+        - cvxopt  # [not s390x]
       source_files:
         - cvxpy/tests
       imports:
@@ -52,7 +53,7 @@ outputs:
         {% set tests_to_skip = "_not_a_real_test" %}
         # test sets intentionally too small timelimit, and then fails
         {% set tests_to_skip = tests_to_skip + " or test_scipy_mi_time_limit_reached " %}
-        - pytest cvxpy/tests -v -k "not ({{ tests_to_skip }})"
+        - pytest cvxpy/tests -v -k "not ({{ tests_to_skip }})"  # [not s390x]
         - pip check
 
   - name: cvxpy-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,7 +77,7 @@ outputs:
         - cvxpy
 
 about:
-  home: http://www.cvxpy.org/
+  home: https://www.cvxpy.org/
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
@@ -87,7 +87,7 @@ about:
     problems. It allows you to express your problem in a natural way that
     follows the math, rather than in the restrictive standard form required
     by solvers.
-  doc_url: http://www.cvxpy.org/
+  doc_url: https://www.cvxpy.org/
   dev_url: https://github.com/cvxpy/cvxpy
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,6 @@ outputs:
         - {{ compiler('cxx') }}
       host:
         - python
-        # conda-forge recipe inserts oldest numpy per platform/runtime
         - numpy
         - pip
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ outputs:
         - scs >=1.1.6
     test:
       requires:
+        - pip
         - pytest
         - cvxopt
       source_files:
@@ -48,6 +49,7 @@ outputs:
         # test sets intentionally too small timelimit, and then fails
         {% set tests_to_skip = tests_to_skip + " or test_scipy_mi_time_limit_reached " %}   # [aarch64 or ppc64le]
         - pytest cvxpy/tests -v -k "not ({{ tests_to_skip }})"
+        - pip check
 
   - name: cvxpy-base
     build:
@@ -72,6 +74,7 @@ outputs:
         - {{ pin_compatible('numpy') }}
         - scipy >=1.1.0
     test:
+      # pip check fails for cvxpy-base due to checking for optional dependencies.
       imports:
         # public interface is defined (see #75) to be the content of
         # https://github.com/cvxpy/cvxpy/blob/master/cvxpy/__init__.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,9 +57,6 @@ outputs:
         - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
     requirements:
       build:
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - numpy                                  # [build_platform != target_platform]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,9 +54,7 @@ outputs:
   - name: cvxpy-base
     build:
       script:
-        - rm $SRC_DIR/pyproject.toml    # [unix]
-        - del %SRC_DIR%\pyproject.toml  # [win]
-        - {{ PYTHON }} -m pip install . --no-deps -vvv
+        - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
     requirements:
       build:
         - python                                 # [build_platform != target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,9 @@ requirements:
 
 outputs:
   - name: cvxpy
+    build:
+      # scs missing on Windows
+      skip: true  # [win]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  # s390x missing cvxopt
   skip: true  # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,6 +63,8 @@ outputs:
         - python
         - numpy
         - pip
+        - setuptools
+        - wheel
       run:
         - python
         - {{ pin_compatible('numpy') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<37]
 
-# Need these up here for conda-smithy to handle them properly.
 requirements:
   build:
     - python                                 # [build_platform != target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,6 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ outputs:
       commands:
         {% set tests_to_skip = "_not_a_real_test" %}
         # test sets intentionally too small timelimit, and then fails
-        {% set tests_to_skip = tests_to_skip + " or test_scipy_mi_time_limit_reached " %}   # [aarch64 or ppc64le]
+        {% set tests_to_skip = tests_to_skip + " or test_scipy_mi_time_limit_reached " %}
         - pytest cvxpy/tests -v -k "not ({{ tests_to_skip }})"
         - pip check
 


### PR DESCRIPTION
[Upstream repo](https://github.com/cvxpy/cvxpy)

Target channel: Snowflake ❄️

- Building only `cvxpy-base` for Windows; Missing `scs`.
- Skipping tests on s390x; Missing `cvxopt`.
- Skip `test_scipy_mi_time_limit_reached` on all platforms.
- No `pip check` for `cvxpy-base` output because it checks for the full dependencies of `cvxpy`.