### PR TITLE
PKG-14953: rebuild cvxpy 1.8.2 against pybind11 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,6 +80,7 @@ outputs:
         - pip
         - python
         - pybind11
+        - pybind11-abi
         - setuptools >=68.1.0
         - numpy >=2.0.0
         - scipy >=1.13.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c75489ebf09d1bd21c009b410f4e2fafe5b1704c1e46c45b1346f09e9f925974
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<311]
 
 requirements:


### PR DESCRIPTION
cvxpy 1.8.2

**Destination channel:** Defaults

### Links

- [PKG-14953](https://anaconda.atlassian.net/browse/PKG-14953)
- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic)
- Relevant dependency PRs:
  - AnacondaRecipes/pybind11-feedstock#24 (pybind11 3.0.4 — **MERGED**)
  - AnacondaRecipes/repodata-hotfixes#318 (scope reduction — **applied**)
  - AnacondaRecipes/osqp-feedstock#7, AnacondaRecipes/qdldl-python-feedstock#6 (companion rebuilds)

### Explanation of changes:

- **Build number 0 -> 1** (no source change). Rebuild against pybind11 3.0.4 from pkgs/main.
- **Result:** both `cvxpy` and `cvxpy-base` outputs will declare `pybind11-abi ==11` via pybind11-abi's run_export.
- **Why:** cvxpy exchanges C++ problem/constraint types cross-module with osqp and qdldl-python. Per Charles's PKG-13552 hotfix-scope analysis, retained in the slim `MISSING_PYBIND11_ABI_VERSION_RANGES` table after #318.

[PKG-14953]: https://anaconda.atlassian.net/browse/PKG-14953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ